### PR TITLE
Flexible logging

### DIFF
--- a/epos-server/go.mod
+++ b/epos-server/go.mod
@@ -1,0 +1,9 @@
+module epos-server
+
+go 1.12
+
+require (
+	github.com/gorilla/mux v1.8.0
+	github.com/knq/escpos v0.0.0-20201012084129-81d0344e35fa
+	github.com/moovweb/gokogiri v0.0.0-20180713195410-a1a828153468
+)

--- a/epos-server/go.sum
+++ b/epos-server/go.sum
@@ -1,0 +1,6 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/knq/escpos v0.0.0-20201012084129-81d0344e35fa h1:Gqf0Q4Wra8RDXSaHwNKHcEJY0osaSklMXi5EnLLpuhM=
+github.com/knq/escpos v0.0.0-20201012084129-81d0344e35fa/go.mod h1:WEAqQJjNLSktlp0XxBiiftFrcb0RHKo9g/2hCfpYoIo=
+github.com/moovweb/gokogiri v0.0.0-20180713195410-a1a828153468 h1:s7OD9KAZ/X1BdIlXtaZUgROv/5OaFo1MlsSetrtxIis=
+github.com/moovweb/gokogiri v0.0.0-20180713195410-a1a828153468/go.mod h1:Oa/X457L/tmlvYXbM/iG0y+G1EERtHrpp7Y4fHJwsrk=

--- a/example/image2pos/go.mod
+++ b/example/image2pos/go.mod
@@ -1,0 +1,5 @@
+module image2pos
+
+go 1.12
+
+require github.com/knq/escpos v0.0.0-20201012084129-81d0344e35fa

--- a/example/image2pos/go.sum
+++ b/example/image2pos/go.sum
@@ -1,0 +1,2 @@
+github.com/knq/escpos v0.0.0-20201012084129-81d0344e35fa h1:Gqf0Q4Wra8RDXSaHwNKHcEJY0osaSklMXi5EnLLpuhM=
+github.com/knq/escpos v0.0.0-20201012084129-81d0344e35fa/go.mod h1:WEAqQJjNLSktlp0XxBiiftFrcb0RHKo9g/2hCfpYoIo=

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kenshaw/escpos
+
+go 1.12


### PR DESCRIPTION
Depends on: #24
Fixes #22

This PR makes the logging of this module configurable.
It does so by exposing an optional `SetLogger( ... )` method, that allows the user to specify a custom logger.

This also changes the default behaviour of the module. In fact nothing will be logged by default.

Users can restore the previous behaviour by specifying a custom logger that provides the same logging formatting:
```
p := escpos.New(f)
logger := log.New(log.Default().Writer(), "", 0)
p.SetLogger(logger)
```


